### PR TITLE
include all docs

### DIFF
--- a/.github/workflows/multidocs.yml
+++ b/.github/workflows/multidocs.yml
@@ -20,81 +20,63 @@ jobs:
       - name: Set up
         run: git config --global init.defaultBranch master
       
-      # Build GNNGraphs docs
-      - name: Install dependencies for GNNGraphs
+      - name: Build GNNGraphs docs
         run: 
           julia --project=GNNGraphs/docs/ -e '
-          using Pkg;
-          Pkg.develop(PackageSpec(path=joinpath(pwd(), "GNNGraphs")));
-          Pkg.instantiate();'
-      - name: Build GNNGraphs docs
+          using Pkg
+          pkg"dev ./GNNGraphs"
+          Pkg.instantiate()
+          include("GNNGraphs/docs/make.jl")'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=GNNGraphs/docs/ GNNGraphs/docs/make.jl
     
-      # Build GNNlib docs
-      - name: Install dependencies for GNNlib
-        run: julia --project=GNNlib/docs/ -e 'using Pkg; Pkg.instantiate();'
       - name: Build GNNlib docs
+        run: julia --project=GNNlib/docs/ -e '
+          using Pkg
+          pkg"dev ./GNNlib ./GNNGraphs"
+          Pkg.instantiate()
+          include("GNNlib/docs/make.jl")'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=GNNlib/docs/ GNNlib/docs/make.jl
   
-      # Build GNNLux docs
-      - name: Install dependencies for GNNLux
-        run: julia --project=GNNLux/docs/ -e '
-            using Pkg;
-            Pkg.develop(PackageSpec(path=joinpath(pwd(), "GNNLux"))); 
-            Pkg.instantiate();'
       - name: Build GNNLux docs
+        run: julia --project=GNNLux/docs/ -e '
+            using Pkg
+            pkg"dev ./GNNLux ./GNNlib ./GNNGraphs"
+            Pkg.instantiate()
+            include("GNNLux/docs/make.jl")'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=GNNLux/docs/ GNNLux/docs/make.jl
 
-      # Build GraphNeuralNetworks docs
-      - name: Install dependencies for GraphNeuralNetworks
-        run: julia --project=GraphNeuralNetworks/docs/ -e '
-            using Pkg;
-            Pkg.develop(PackageSpec(path=joinpath(pwd(), "GraphNeuralNetworks"))); 
-            Pkg.instantiate();'
       - name: Build GraphNeuralNetworks docs
+        run: julia --project=GraphNeuralNetworks/docs/ -e '
+            using Pkg
+            pkg"dev ./GraphNeuralNetworks ./GNNlib ./GNNGraphs"
+            Pkg.instantiate()
+            include("GraphNeuralNetworks/docs/make.jl")'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=GraphNeuralNetworks/docs/ GraphNeuralNetworks/docs/make.jl
-
-      # Build  multidocs
-      - name: Install dependencies for main docs
-        run: julia --project=GraphNeuralNetworks/docs/ -e ' 
-            using Pkg;
-            Pkg.develop(PackageSpec(path=joinpath(pwd(), "GraphNeuralNetworks"))); 
-            Pkg.instantiate();'
-      - name: Build main docs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=GraphNeuralNetworks/docs/make.jl
 
       # Build tutorials
       - name: Install dependencies for tutorials
-        run: julia --project=tutorials/docs/ -e 'using Pkg; Pkg.instantiate();'
-      - name: Build tutorials
+        run: julia --project=tutorials/docs/ -e '
+          using Pkg
+          pkg"dev ./GraphNeuralNetworks ./GNNlib ./GNNGraphs"
+          Pkg.instantiate()
+          include("tutorials/docs/make.jl")'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=tutorials/docs/ tutorials/docs/make.jl
-
+      
       # Build and deploy multidocs
       - name: Install dependencies for multidocs
         run: julia --project=docs/ -e '
           using Pkg;
-          Pkg.develop([PackageSpec(path=joinpath(pwd(), "GraphNeuralNetworks")),
-                      PackageSpec(path=joinpath(pwd(), "GNNGraphs")),
-                      PackageSpec(path=joinpath(pwd(), "GNNlib")),
-                      PackageSpec(path=joinpath(pwd(), "GNNLux"))]);
+          pkg"dev ./GraphNeuralNetworks ./GNNlib ./GNNGraphs ./GNNLux"
           Pkg.instantiate();'
       - name: Check if objects.inv exists for GraphNeuralNetworks
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ GNNGraphs/docs/build
 GNNlib/docs/build
 GNNLux/docs/build
 GraphNeuralNetworks/docs/build
-GraphNeuralNetworks/docs/src/other
+GraphNeuralNetworks/docs/src/GNNGraphs
+GraphNeuralNetworks/docs/src/GNNlib
 tutorials/docs/build

--- a/GNNlib/docs/src/api/utils.md
+++ b/GNNlib/docs/src/api/utils.md
@@ -31,9 +31,9 @@ broadcast_edges
 softmax_edge_neighbors
 ```
 
-### NNlib
+### NNlib's gather and scatter functions
 
-Primitive functions implemented in NNlib.jl:
+Primitive functions for message passing implemented in [NNlib.jl](https://fluxml.ai/NNlib.jl/stable/reference/#Gather-and-Scatter):
 
 - [`gather!`](https://fluxml.ai/NNlib.jl/stable/reference/#NNlib.gather!)
 - [`gather`](https://fluxml.ai/NNlib.jl/stable/reference/#NNlib.gather)

--- a/GNNlib/docs/src/guides/messagepassing.md
+++ b/GNNlib/docs/src/guides/messagepassing.md
@@ -28,8 +28,8 @@ manipulating arrays of size ``D_{node} \times num\_nodes`` and
 1. [`apply_edges`](@ref) materializes node features on edges and applies the message function. 
 2. [`aggregate_neighbors`](@ref) applies a reduction operator on the messages coming from the neighborhood of each node.
 
-The whole propagation mechanism internally relies on the [`NNlib.gather`](@ref) 
-and [`NNlib.scatter`](@ref) methods.
+The whole propagation mechanism internally relies on the [`NNlib.gather`](@extref) 
+and [`NNlib.scatter`](@extref) methods.
 
 
 ## Examples

--- a/GraphNeuralNetworks/docs/Project.toml
+++ b/GraphNeuralNetworks/docs/Project.toml
@@ -1,4 +1,12 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+GNNGraphs = "aed8fd31-079b-4b5a-b342-a13352159b8c"
+GNNlib = "a6a84749-d869-43f8-aacc-be26a1996e48"
 GraphNeuralNetworks = "cffab07f-9bc2-4db1-8861-388f63bf7694"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/GraphNeuralNetworks/docs/make.jl
+++ b/GraphNeuralNetworks/docs/make.jl
@@ -1,57 +1,75 @@
 using Documenter
 using GraphNeuralNetworks
+using Flux, GNNGraphs, GNNlib, Graphs, NNlib
+# using GNNGraphs, GNNlib # no need to load since they are re-exported by GraphNeuralNetworks
 using DocumenterInterLinks
 
+DocMeta.setdocmeta!(GraphNeuralNetworks, :DocTestSetup, :(using GraphNeuralNetworks); recursive = true)
 
-assets=[]
-prettyurls = get(ENV, "CI", nothing) == "true"
-mathengine = MathJax3()
+mathengine = MathJax3(Dict(:loader => Dict("load" => ["[tex]/require", "[tex]/mathtools"]),
+    :tex => Dict("inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
+        "packages" => [
+            "base",
+            "ams",
+            "autoload",
+            "mathtools",
+            "require"
+        ])))
+
 
 interlinks = InterLinks(
     "NNlib" => "https://fluxml.ai/NNlib.jl/stable/",
-    "GNNGraphs" => ("https://carlolucibello.github.io/GraphNeuralNetworks.jl/GNNGraphs/",  joinpath(dirname(dirname(@__DIR__)), "GNNGraphs", "docs", "build", "objects.inv")),
-    "GNNlib" => ("https://carlolucibello.github.io/GraphNeuralNetworks.jl/GNNlib/",  joinpath(dirname(dirname(@__DIR__)), "GNNlib", "docs", "build", "objects.inv"))
-   
+    # "GNNGraphs" => ("https://carlolucibello.github.io/GraphNeuralNetworks.jl/GNNGraphs/",  joinpath(dirname(dirname(@__DIR__)), "GNNGraphs", "docs", "build", "objects.inv")),
+    # "GNNlib" => ("https://carlolucibello.github.io/GraphNeuralNetworks.jl/GNNlib/",  joinpath(dirname(dirname(@__DIR__)), "GNNlib", "docs", "build", "objects.inv"))
    )
 
-# Copy the guides from GNNGraphs and GNNlib
-dest_guides_dir = joinpath(@__DIR__, "src/other")
-gnngraphs_guides_dir = joinpath(@__DIR__, "../../GNNGraphs/docs/src/guides")
-gnnlib_guides_dir = joinpath(@__DIR__, "../../GNNlib/docs/src/guides") 
-for file in readdir(gnngraphs_guides_dir)
-    cp(joinpath(gnngraphs_guides_dir, file), joinpath(dest_guides_dir, file), force=true)
-end
-for file in readdir(gnnlib_guides_dir)
-    cp(joinpath(gnnlib_guides_dir, file), joinpath(dest_guides_dir, file), force=true)
-end
+# Copy the docs from GNNGraphs and GNNlib. Will be removed at the end of the script
+cp(joinpath(@__DIR__, "../../GNNGraphs/docs/src"),
+   joinpath(@__DIR__, "src/GNNGraphs"), force=true)
+cp(joinpath(@__DIR__, "../../GNNlib/docs/src"),
+   joinpath(@__DIR__, "src/GNNlib"), force=true)
 
 makedocs(;
-    modules = [GraphNeuralNetworks],
+    modules = [GraphNeuralNetworks, GNNGraphs, GNNlib],
     doctest = false, # TODO: enable doctest
-    clean = true,
     plugins = [interlinks],
-    format = Documenter.HTML(; mathengine, prettyurls, assets = assets, size_threshold=nothing),
+    format = Documenter.HTML(; mathengine, 
+                            prettyurls = get(ENV, "CI", nothing) == "true", 
+                            assets = [],
+                            size_threshold=nothing, 
+                            size_threshold_warn=200000),
     sitename = "GraphNeuralNetworks.jl",
     pages = [
     
     "Home" => "index.md",
     
     "Guides" => [
-        "Graphs" => ["other/gnngraph.md", "other/heterograph.md", "other/temporalgraph.md"],
-        "Message Passing" => "other/messagepassing.md",
+        "Graphs" => ["GNNGraphs/guides/gnngraph.md", 
+                    "GNNGraphs/guides/heterograph.md", 
+                    "GNNGraphs/guides/temporalgraph.md"],
+        "Message Passing" => "GNNlib/guides/messagepassing.md",
         "Models" => "guides/models.md",
-        "Datasets" => "other/datasets.md",
+        "Datasets" => "GNNGraphs/guides/datasets.md",
     ],
 
     "API Reference" => [
+            "Message Passing" => "GNNlib/api/messagepassing.md",
+            "Utils" => "GNNlib/api/utils.md",
             "Basic" => "api/basic.md",
             "Convolutional layers" => "api/conv.md",
             "Pooling layers" => "api/pool.md",
             "Temporal Convolutional layers" => "api/temporalconv.md",
             "Hetero Convolutional layers" => "api/heteroconv.md",
+
         ],
-        "Developer guide" => "dev.md",
+    
+    "Developer guide" => "dev.md",
     ],
 )
-         
-deploydocs(;repo = "github.com/JuliaGraphs/GraphNeuralNetworks.jl.git", devbranch = "master", dirname= "GraphNeuralNetworks")
+
+rm(joinpath(@__DIR__, "src/GNNGraphs"), force=true, recursive=true)
+rm(joinpath(@__DIR__, "src/GNNlib"), force=true, recursive=true)
+
+deploydocs(repo = "github.com/JuliaGraphs/GraphNeuralNetworks.jl.git", 
+          devbranch = "master", 
+          dirname= "GraphNeuralNetworks")


### PR DESCRIPTION
Make the GNN.jl documentation self-consistent by copying over doc source files from GNNGraphs and GNNlib. 
This way we don't have to jump around to read the documentation.