### PR TITLE
Feature: TGCN should support non linear_activations

### DIFF
--- a/GNNLux/src/layers/temporalconv.jl
+++ b/GNNLux/src/layers/temporalconv.jl
@@ -33,9 +33,11 @@ LuxCore.apply(m::GNNContainerLayer, g, x, ps, st) = m(g, x, ps, st)
     init_state::Function
 end
 
-function TGCNCell(ch::Pair{Int, Int}; use_bias = true, init_weight = glorot_uniform, init_state = zeros32, init_bias = zeros32, add_self_loops = false, use_edge_weight = true) 
+function TGCNCell(ch::Pair{Int, Int}; use_bias = true, init_weight = glorot_uniform, 
+                    init_state = zeros32, init_bias = zeros32, add_self_loops = false, 
+                    use_edge_weight = true, act = relu) 
     in_dims, out_dims = ch
-    conv = GCNConv(ch, sigmoid; init_weight, init_bias, use_bias, add_self_loops, use_edge_weight)
+    conv = GCNConv(ch, act; init_weight, init_bias, use_bias, add_self_loops, use_edge_weight)
     gru = Lux.GRUCell(out_dims => out_dims; use_bias, init_weight = (init_weight, init_weight, init_weight), init_bias = (init_bias, init_bias, init_bias), init_state = init_state)
     return TGCNCell(in_dims, out_dims, conv, gru, init_state)
 end
@@ -57,7 +59,7 @@ function Base.show(io::IO, tgcn::TGCNCell)
 end
 
 """
-    TGCN(in => out; use_bias = true, init_weight = glorot_uniform, init_state = zeros32, init_bias = zeros32, add_self_loops = false, use_edge_weight = true) 
+    TGCN(in => out; use_bias = true, init_weight = glorot_uniform, init_state = zeros32, init_bias = zeros32, add_self_loops = false, use_edge_weight = true, act = sigmoid) 
 
 Temporal Graph Convolutional Network (T-GCN) recurrent layer from the paper [T-GCN: A Temporal Graph Convolutional Network for Traffic Prediction](https://arxiv.org/pdf/1811.05320.pdf).
 
@@ -76,7 +78,7 @@ Performs a layer of GCNConv to model spatial dependencies, followed by a Gated R
                      If `add_self_loops=true` the new weights will be set to 1. 
                      This option is ignored if the `edge_weight` is explicitly provided in the forward pass.
                      Default `false`.
-
+- `act`: Activation function used in the GCNConv layer. Default `relu`.
 
 
 # Examples
@@ -91,8 +93,11 @@ rng = Random.default_rng()
 g = rand_graph(rng, 5, 10)
 x = rand(rng, Float32, 2, 5)
 
-# create TGCN layer
+# create TGCN layer with default activation (relu)
 tgcn = TGCN(2 => 6)
+
+# create TGCN layer with custom activation
+tgcn_relu = TGCN(2 => 6, act = sigmoid)
 
 # setup layer
 ps, st = LuxCore.setup(rng, tgcn)

--- a/GNNLux/src/layers/temporalconv.jl
+++ b/GNNLux/src/layers/temporalconv.jl
@@ -93,7 +93,7 @@ rng = Random.default_rng()
 g = rand_graph(rng, 5, 10)
 x = rand(rng, Float32, 2, 5)
 
-# create TGCN layer with default activation (sigmoid)
+# create TGCN layer 
 tgcn = TGCN(2 => 6)
 
 # create TGCN layer with custom activation

--- a/GNNLux/src/layers/temporalconv.jl
+++ b/GNNLux/src/layers/temporalconv.jl
@@ -35,7 +35,7 @@ end
 
 function TGCNCell(ch::Pair{Int, Int}; use_bias = true, init_weight = glorot_uniform, 
                     init_state = zeros32, init_bias = zeros32, add_self_loops = false, 
-                    use_edge_weight = true, act = relu) 
+                    use_edge_weight = true, act = sigmoid) 
     in_dims, out_dims = ch
     conv = GCNConv(ch, act; init_weight, init_bias, use_bias, add_self_loops, use_edge_weight)
     gru = Lux.GRUCell(out_dims => out_dims; use_bias, init_weight = (init_weight, init_weight, init_weight), init_bias = (init_bias, init_bias, init_bias), init_state = init_state)
@@ -59,7 +59,7 @@ function Base.show(io::IO, tgcn::TGCNCell)
 end
 
 """
-    TGCN(in => out; use_bias = true, init_weight = glorot_uniform, init_state = zeros32, init_bias = zeros32, add_self_loops = false, use_edge_weight = true, act = sigmoid) 
+    TGCN(in => out; use_bias = true, init_weight = glorot_uniform, init_state = zeros32, init_bias = zeros32, add_self_loops = false, use_edge_weight = true, act = relu) 
 
 Temporal Graph Convolutional Network (T-GCN) recurrent layer from the paper [T-GCN: A Temporal Graph Convolutional Network for Traffic Prediction](https://arxiv.org/pdf/1811.05320.pdf).
 

--- a/GNNLux/src/layers/temporalconv.jl
+++ b/GNNLux/src/layers/temporalconv.jl
@@ -59,7 +59,7 @@ function Base.show(io::IO, tgcn::TGCNCell)
 end
 
 """
-    TGCN(in => out; use_bias = true, init_weight = glorot_uniform, init_state = zeros32, init_bias = zeros32, add_self_loops = false, use_edge_weight = true, act = relu) 
+    TGCN(in => out; use_bias = true, init_weight = glorot_uniform, init_state = zeros32, init_bias = zeros32, add_self_loops = false, use_edge_weight = true, act = sigmoid) 
 
 Temporal Graph Convolutional Network (T-GCN) recurrent layer from the paper [T-GCN: A Temporal Graph Convolutional Network for Traffic Prediction](https://arxiv.org/pdf/1811.05320.pdf).
 
@@ -78,7 +78,7 @@ Performs a layer of GCNConv to model spatial dependencies, followed by a Gated R
                      If `add_self_loops=true` the new weights will be set to 1. 
                      This option is ignored if the `edge_weight` is explicitly provided in the forward pass.
                      Default `false`.
-- `act`: Activation function used in the GCNConv layer. Default `relu`.
+- `act`: Activation function used in the GCNConv layer. Default `sigmoid`.
 
 
 # Examples
@@ -93,11 +93,11 @@ rng = Random.default_rng()
 g = rand_graph(rng, 5, 10)
 x = rand(rng, Float32, 2, 5)
 
-# create TGCN layer with default activation (relu)
+# create TGCN layer with default activation (sigmoid)
 tgcn = TGCN(2 => 6)
 
 # create TGCN layer with custom activation
-tgcn_relu = TGCN(2 => 6, act = sigmoid)
+tgcn_relu = TGCN(2 => 6, act = relu)
 
 # setup layer
 ps, st = LuxCore.setup(rng, tgcn)

--- a/GNNLux/test/layers/temporalconv.jl
+++ b/GNNLux/test/layers/temporalconv.jl
@@ -10,7 +10,7 @@
     tx = [x for _ in 1:5]
 
     @testset "TGCN" begin
-        # Test with default activation (relu)
+        # Test with default activation (sigmoid)
         l = TGCN(3=>3)
         ps = LuxCore.initialparameters(rng, l)
         st = LuxCore.initialstates(rng, l)
@@ -18,8 +18,8 @@
         loss = (x, ps) -> sum(first(l(g, x, ps, st)))
         test_gradients(loss, x, ps; atol=1.0f-2, rtol=1.0f-2, skip_backends=[AutoReverseDiff(), AutoTracker(), AutoForwardDiff(), AutoEnzyme()])
         
-        # Test with custom activation (sigmoid)
-        l_relu = TGCN(3=>3, act = sigmoid)
+        # Test with custom activation (relu)
+        l_relu = TGCN(3=>3, act = relu)
         ps_relu = LuxCore.initialparameters(rng, l_relu)
         st_relu = LuxCore.initialstates(rng, l_relu)
         y2, _ = l_relu(g, x, ps_relu, st_relu)

--- a/GNNLux/test/layers/temporalconv.jl
+++ b/GNNLux/test/layers/temporalconv.jl
@@ -10,11 +10,25 @@
     tx = [x for _ in 1:5]
 
     @testset "TGCN" begin
+        # Test with default activation (relu)
         l = TGCN(3=>3)
         ps = LuxCore.initialparameters(rng, l)
         st = LuxCore.initialstates(rng, l)
+        y1, _ = l(g, x, ps, st)
         loss = (x, ps) -> sum(first(l(g, x, ps, st)))
         test_gradients(loss, x, ps; atol=1.0f-2, rtol=1.0f-2, skip_backends=[AutoReverseDiff(), AutoTracker(), AutoForwardDiff(), AutoEnzyme()])
+        
+        # Test with custom activation (sigmoid)
+        l_relu = TGCN(3=>3, act = sigmoid)
+        ps_relu = LuxCore.initialparameters(rng, l_relu)
+        st_relu = LuxCore.initialstates(rng, l_relu)
+        y2, _ = l_relu(g, x, ps_relu, st_relu)
+        
+        # Outputs should be different with different activation functions
+        @test !isapprox(y1, y2, rtol=1.0f-2)
+        
+        loss_relu = (x, ps) -> sum(first(l_relu(g, x, ps, st_relu)))
+        test_gradients(loss_relu, x, ps_relu; atol=1.0f-2, rtol=1.0f-2, skip_backends=[AutoReverseDiff(), AutoTracker(), AutoForwardDiff(), AutoEnzyme()])
     end
 
     @testset "A3TGCN" begin

--- a/GraphNeuralNetworks/src/layers/temporalconv.jl
+++ b/GraphNeuralNetworks/src/layers/temporalconv.jl
@@ -869,12 +869,12 @@ See [`GNNRecurrence`](@ref) for more details.
 
 # Additional Parameters
 
-- `gate_activation`: Activation function for the gate mechanisms. Default `sigmoid`.
+- `act`: Activation function for the GCNConv layers. Default `relu`.
 
 # Examples
 
 ```jldoctest
-julia> using Flux  # Ensure relu is available
+julia> using Flux  # Ensure activation functions are available
 
 julia> num_nodes, num_edges = 5, 10;
 

--- a/GraphNeuralNetworks/src/layers/temporalconv.jl
+++ b/GraphNeuralNetworks/src/layers/temporalconv.jl
@@ -758,7 +758,7 @@ EvolveGCNO(args...; kws...) = GNNRecurrence(EvolveGCNOCell(args...; kws...))
 
 
 """
-    TGCNCell(in => out; act = relu, kws...)
+    TGCNCell(in => out, act = relu, kws...)
 
 Recurrent graph convolutional cell from the paper
 [T-GCN: A Temporal Graph Convolutional
@@ -860,16 +860,12 @@ function Base.show(io::IO, cell::TGCNCell)
 end
 
 """
-    TGCN(args...; act = relu, kws...)
+    TGCN(args...; kws...)
 
 Construct a recurrent layer corresponding to the [`TGCNCell`](@ref) cell.
 
 The arguments are passed to the [`TGCNCell`](@ref) constructor.
 See [`GNNRecurrence`](@ref) for more details.
-
-# Additional Parameters
-
-- `act`: Activation function for the GCNConv layers. Default `relu`.
 
 # Examples
 
@@ -902,6 +898,6 @@ julia> size(y) # (d_out, timesteps, num_nodes)
 (3, 5, 5)
 ```
 """
-TGCN(args...; act = relu, kws...) = 
-    GNNRecurrence(TGCNCell(args...; act, kws...))
+TGCN(args...; kws...) = 
+    GNNRecurrence(TGCNCell(args...; kws...))
 


### PR DESCRIPTION
Hi again @CarloLucibello 

## Changes in this PR – Solving Issue #591  

- [x] Implemented custom linear activations (`gate_activation`) in the temporal graph layer cells for `GraphNeuralNetworks`, with corresponding tests.  
- [x] Implemented custom linear activations (`gate_activation`) in the temporal graph layer cells for `GNNLux`, with corresponding tests.  

## Notes & Open Questions  

- Currently, only the **sigmoid gate activation functions** have been modified based on the referenced paper.  
- Should we also modify the **tanh** activation?  
  - In `Flux`, this change is straightforward.  
  - However, for `Lux`, we might need an alternative to `Lux.GruCell`, as it **uses tanh by default** (as far as I understand) and may not be easily modifiable.  
  - Let me know if the tests cover the necessary cases effectively.  

- I'll have the proposal between **Tuesday and Wednesday**. If you could review it as recommended for the **GSoC application Julia Guidelines** , I’d really appreciate it your help.

Let me know your thoughts! 🚀 It’s working on my end—please confirm if it runs for you.



