### PR TITLE
fix: Gate empty result in GATConv

### DIFF
--- a/GNNlib/src/layers/conv.jl
+++ b/GNNlib/src/layers/conv.jl
@@ -139,11 +139,12 @@ function gat_conv(l, g::AbstractGNNGraph, x, e::Union{Nothing, AbstractMatrix} =
     α = dropout(α, l.dropout)
     β = α .* m.Wxj
     x = aggregate_neighbors(g, +, β)
+    width = size(x, 1)
 
     if !l.concat
         x = mean(x, dims = 2)
     end
-    x = reshape(x, :, size(x, 3))  # return a matrix
+    x = reshape(x, width, size(x, 3))  # return a matrix
     x = l.σ.(x .+ l.bias)
 
     return x

--- a/GNNlib/src/layers/conv.jl
+++ b/GNNlib/src/layers/conv.jl
@@ -124,13 +124,10 @@ function gat_conv(l, g::AbstractGNNGraph, x, e::Union{Nothing, AbstractMatrix} =
     _, chout = l.channel
     heads = l.heads
 
-    Wxi = Wxj = l.dense_x(xj)
-    Wxi = Wxj = reshape(Wxj, chout, heads, :)                   
-
-    if xi !== xj
-        Wxi = l.dense_x(xi)
-        Wxi = reshape(Wxi, chout, heads, :)                   
-    end
+    Wxj = l.dense_x(xj)
+    Wxj = reshape(Wxj, chout, heads, :)
+    Wxi = l.dense_x(xi)
+    Wxi = reshape(Wxi, chout, heads, :)
 
     # a hand-written message passing
     message = Fix1(gat_message, l)
@@ -139,10 +136,12 @@ function gat_conv(l, g::AbstractGNNGraph, x, e::Union{Nothing, AbstractMatrix} =
     α = dropout(α, l.dropout)
     β = α .* m.Wxj
     x = aggregate_neighbors(g, +, β)
-    width = size(x, 1)
 
     if !l.concat
         x = mean(x, dims = 2)
+        width = size(x, 1)
+    else
+        width = size(x, 1) * size(x, 2)
     end
     x = reshape(x, width, size(x, 3))  # return a matrix
     x = l.σ.(x .+ l.bias)
@@ -195,8 +194,11 @@ function gatv2_conv(l, g::AbstractGNNGraph, x, e::Union{Nothing, AbstractMatrix}
 
     if !l.concat
         x = mean(x, dims = 2)
+        width = size(x, 1)
+    else
+        width = size(x, 1) * size(x, 2)
     end
-    x = reshape(x, :, size(x, 3))
+    x = reshape(x, width, size(x, 3))
     x = l.σ.(x .+ l.bias)
     return x
 end

--- a/GNNlib/src/layers/conv.jl
+++ b/GNNlib/src/layers/conv.jl
@@ -121,13 +121,15 @@ function gat_conv(l, g::AbstractGNNGraph, x, e::Union{Nothing, AbstractMatrix} =
         g = add_self_loops(g)
     end
 
+    _, n_stackj = size(xj)
+    _, n_stacki = size(xi)
     _, chout = l.channel
     heads = l.heads
 
     Wxj = l.dense_x(xj)
-    Wxj = reshape(Wxj, chout, heads, :)
+    Wxj = reshape(Wxj, chout, heads, n_stackj)
     Wxi = l.dense_x(xi)
-    Wxi = reshape(Wxi, chout, heads, :)
+    Wxi = reshape(Wxi, chout, heads, n_stacki)
 
     # a hand-written message passing
     message = Fix1(gat_message, l)


### PR DESCRIPTION
Resolves #637

Fixes 3 problems:

1. In `gat_conv` during backpropagation, "DimensionMismatch: arrays could not be broadcast to a common size". This could be solved by removing the conditional used to calculate `Wxi, Wxj`:
```julia
    Wxj = l.dense_x(xj)
    Wxj = reshape(Wxj, chout, heads, :)
    Wxi = l.dense_x(xi)
    Wxi = reshape(Wxi, chout, heads, :)
```
2. The `reshape(x, :, size(x, 3))` in `gat_conv` creates incompatible sizes when `x` is empty. This PR determines the size using the first two axes of `x` instead.
3. The empty array problem `DimensionMismatch: variable with size(x) == (1, 1, 0) cannot have a gradient with size(dx) == (4, 1, 0)`. This could be fixed by a patch for `ChainRulesCore.jl` https://github.com/JuliaDiff/ChainRulesCore.jl/pull/702

Test script:
```julia
using GNNGraphs, GraphNeuralNetworks, NNlib, Flux

graph = GNNHeteroGraph(
    Dict(
        (:A, :a, :B) => ([1, 2], [3, 4]),
        (:B, :a, :A) => ([1], [2]),
        (:C, :a, :A) => (Int[], Int[]),
        (:A, :a, :C) => (Int[], Int[]),
        (:D, :a, :A) => (Int[], Int[]),
        (:E, :a, :A) => (Int[], Int[]),
        (:E, :a, :D) => (Int[], Int[]),
        (:D, :a, :E) => (Int[], Int[]),
    );
    num_nodes = Dict(
        :A => 3, :B => 5,
        :C => 7, :D => 0, :E => 0,
    )
)

width = 9
layer = HeteroGraphConv(
    [
        (src, edge, dst) => GATConv(width => width, NNlib.elu; dropout = Float32(0.25), add_self_loops = true) for
        (src, edge, dst) in keys(graph.edata)
    ];
)
layer2 = HeteroGraphConv(
    [
        (src, edge, dst) => GATConv(width => width, NNlib.elu; dropout = Float32(0.25), add_self_loops = true) for
        (src, edge, dst) in keys(graph.edata)
    ];
)

x = (
    A = rand(Float32, width, 3),
    B = rand(Float32, width, 5),
    C = rand(Float32, width, 7),
    D = rand(Float32, width, 0),
    E = rand(Float32, width, 0),
)

x1 = layer(graph, x)
x2 = layer2(graph, x1)
@info "$x2"

g = Flux.gradient(x) do x
    y = layer(graph, x)
    sum(y[:A])
end
```