### PR TITLE
Skip attention dropout in GATConv/GATv2Conv when dropout == 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Entries link to the pull request that introduced them.
 
 **Fixed**
 - Fixed `Enzyme.gradient` failing when differentiating `GCNConv`, `SGConv` and `TAGConv` on `:dense`/`:sparse` adjacency graphs: their adjacency-matrix fallbacks now convert via the Enzyme-differentiable `GNNGraphs._to_coo_graph` instead of the keyword `GNNGraph` constructor. Requires GNNGraphs ≥ 1.5.2 and, for Enzyme, Enzyme ≥ 0.13.197 ([#703]).
+- `GATConv` and `GATv2Conv` skip attention dropout when `dropout == 0`, which also makes them differentiable with Mooncake on CUDA ([#XXX]).
 
 ## GraphNeuralNetworks.jl — Unreleased (towards 1.1.1)
 
@@ -238,4 +239,5 @@ Lux implementations of the graph convolutional, pooling, and temporal layers
 [#704]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/704
 [#707]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/707
 [#706]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/706
+[#709]: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/709
 [FluxML/Zygote.jl#1662]: https://github.com/FluxML/Zygote.jl/issues/1662

--- a/GNNlib/src/layers/conv.jl
+++ b/GNNlib/src/layers/conv.jl
@@ -136,7 +136,8 @@ function gat_conv(l, g::AbstractGNNGraph, x, e::Union{Nothing, AbstractMatrix} =
     message = Fix1(gat_message, l)
     m = apply_edges(message, g, Wxi, Wxj, e)
     α = softmax_edge_neighbors(g, m.logα)
-    α = dropout(α, l.dropout)
+    # Skip at p == 0: NNlib.dropout fetches the (CUDA) RNG before checking p, which Mooncake cannot trace.
+    iszero(l.dropout) || (α = dropout(α, l.dropout))
     β = α .* m.Wxj
     x = aggregate_neighbors(g, +, β)
 
@@ -188,7 +189,7 @@ function gatv2_conv(l, g::AbstractGNNGraph, x, e::Union{Nothing, AbstractMatrix}
     message = Fix1(gatv2_message, l)
     m = apply_edges(message, g, Wxi, Wxj, e)
     α = softmax_edge_neighbors(g, m.logα)
-    α = dropout(α, l.dropout)
+    iszero(l.dropout) || (α = dropout(α, l.dropout))
     β = α .* m.Wxj
     x = aggregate_neighbors(g, +, β)
 


### PR DESCRIPTION
NNlib.dropout(A, p) fetches the RNG (CUDA.default_rng() for CuArray) before it checks p, so dropout = 0 still pulls the CUDA RNG into the traced program, which Mooncake cannot differentiate. Every GATConv/GATv2Conv gradient on the GPU failed under Mooncake (#702).

MWE:
```julia
using CUDA, Flux, Mooncake, NNlib
x = CUDA.rand(Float32, 3, 4)
Flux.gradient(x -> sum(NNlib.dropout(x, 0.0)), Flux.AutoMooncake(), x)
```

```bash
TypeError: in typeassert, expected CoDual{IdDict{Any,Any}, IdDict{Any,Any}},
           got CoDual{IdDict{Any,Any}, NoFData}
```
Fix: skip the dropout call when p == 0 in gat_conv/gatv2_conv (also saves an RNG launch at inference). With it, GATConv and GATv2Conv pass all 96 GPU gradient sites under Mooncake (≤ 2.5e-7 vs Zygote); CPU tests unchanged. dropout > 0 still needs an upstream Mooncake rule for CUDA.default_rng(), tracked in #702.